### PR TITLE
block 'styles' veranderd naar 'head'

### DIFF
--- a/views/index.liquid
+++ b/views/index.liquid
@@ -1,5 +1,13 @@
 {% comment %} Deze altijd binnen halen en deze omringt de content dmv het 'block' gedoe {% endcomment %}
-{% layout './layouts/layout.liquid' %}
+{% layout './layouts/layout.liquid'
+  , title: title %}
+{% comment %} 
+          Zet hier alle dingen die in je head moeten komen
+          (.css of .js bestanden) 
+{% endcomment %}
+{% block head %}
+  <link rel="stylesheet" href="home.css">
+{% endblock %}
 {% block %}
   <h1>hoi!</h1>
 {% endblock %}

--- a/views/layouts/layout.liquid
+++ b/views/layouts/layout.liquid
@@ -1,4 +1,8 @@
-{% render './partials/head.liquid' %}
+{% render './partials/head.liquid'
+  , title: title %}
+{% block head %}
+  <!-- Default styles if not overridden -->
+{% endblock %}</head><body>
 {% comment %} Hier komt je content! {% endcomment %}
 {% block %}
 {% endblock %}

--- a/views/partials/head.liquid
+++ b/views/partials/head.liquid
@@ -4,5 +4,3 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Document</title>
-</head>
-<body>


### PR DESCRIPTION
Dit zodat je hier niet alleen styles kan zetten maar ook scripts en andere onderdelen.

Je code bevat dus altijd 2 `{% block %}`'s, een normale `{% block %}` voor je content en een `{% block head %}` waarin je aangeeft welke styles/scripts je nodig hebt op die pagina.